### PR TITLE
学習結果画面の表示に関する不具合を修正

### DIFF
--- a/app/src/Scenario/Finish/ScoreInfo.tsx
+++ b/app/src/Scenario/Finish/ScoreInfo.tsx
@@ -41,6 +41,7 @@ export const ScoreInfo: React.FC<Props> = ({ testResultInfo }) => {
 
   const avarage = Math.ceil(testResultInfo.allTestAvarage * 10 * 10) / 10;
   const ownBestScore = Math.ceil(testResultInfo.ownBestScore.molecule * 10 * 10) / 10;
+  const isShowableUserDiviation = !Number.isNaN(testResultInfo.userDeviation);
 
   return (
     <>
@@ -54,7 +55,7 @@ export const ScoreInfo: React.FC<Props> = ({ testResultInfo }) => {
         </Typography>
       </Text>
 
-      <Text pl={2}>{`あなたの偏差値 ${testResultInfo.userDeviation}`}</Text>
+      {isShowableUserDiviation ? <Text pl={2}>{`あなたの偏差値 ${testResultInfo.userDeviation}`}</Text> : null}
 
       <Text pl={2}>
         {`テストの平均点: ${avarage}`}

--- a/app/src/Scenario/Finish/UnderstandingGraph.tsx
+++ b/app/src/Scenario/Finish/UnderstandingGraph.tsx
@@ -82,6 +82,7 @@ export const UnderstandingGraph: React.FC<Props> = ({ testResultInfo }) => {
               letterSpacing: 10,
             },
           }}
+          domain={[0, 100]}
           label="理解度(%)"
           axisLabelComponent={<VictoryLabel dy={-25} />}
         />


### PR DESCRIPTION
- 偏差値が算出不能な場合は非表示
- 理解度の遷移グラフのmin,maxを設定